### PR TITLE
fix: support new and old calicoctl repos

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -6,6 +6,10 @@ set -euo pipefail
 [ -z "${ASDF_INSTALL_VERSION+x}" ] && echo "ASDF_INSTALL_VERSION is required" && exit 1
 [ -z "${ASDF_INSTALL_PATH+x}" ] && echo "ASDF_INSTALL_PATH is required" && exit 1
 
+function ver {
+  printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' ');
+}
+
 install() {
   local install_type=$1
   [ "$install_type" != "version" ] && echo "install type, $install_type, is not supported" && exit 1
@@ -16,8 +20,14 @@ install() {
   local bin_install_path="$install_path/bin"
   local bin_path="${bin_install_path}/calicoctl"
 
+  # Use the legacy repo if the version is before 3.22.1
+  base_url="https://github.com/projectcalico/calico"
+  if [ "$(ver $version)" -lt "$(ver 3.22.1)" ]; then
+    base_url="https://github.com/projectcalico/calicoctl"
+  fi
+
   local download_url
-  download_url="https://github.com/projectcalico/calicoctl/releases/download/v${version}/calicoctl-$(platform)-$(arch)"
+  download_url="${base_url}/releases/download/v${version}/calicoctl-$(platform)-$(arch)"
 
   mkdir -p "${bin_install_path}"
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/projectcalico/calicoctl/releases
+legacy_releases_path=https://api.github.com/repos/projectcalico/calicoctl/releases
+releases_path=https://api.github.com/repos/projectcalico/calico/releases
+
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi
-
-cmd="$cmd $releases_path"
 
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort_versions)
+# filter out versions before 3.22.1 -- the start of the calicoctl releases
+# in the new repo
+function filter_before() {
+  sed -n '/3\.22\.1/,$p'
+}
+
+function get_tags() {
+  grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//'
+}
+
+echo $(eval "$cmd $legacy_releases_path" | get_tags | sort_versions) \
+     $(eval "$cmd $releases_path" | get_tags | sort_versions | filter_before)


### PR DESCRIPTION
Support old and new repos.

```
asdf install calicoctl latest
Downloading calicoctl from https://github.com/projectcalico/calico/releases/download/v3.22.1/calicoctl-darwin-amd64

asdf install calicoctl 3.21.4
Downloading calicoctl from https://github.com/projectcalico/calicoctl/releases/download/v3.21.4/calicoctl-darwin-amd64

asdf list-all calicoctl
3.15.5
3.16.8
3.16.9
3.16.10
3.17.2
3.17.3
3.17.4
3.17.5
3.17.6
3.18.0
3.18.1
3.18.2
3.18.3
3.18.4
3.18.5
3.18.6
3.19.0
3.19.1
3.19.2
3.19.3
3.19.4
3.20.0
3.20.1
3.20.2
3.20.3
3.20.4
3.21.0
3.21.1
3.21.2
3.21.4
3.22.1
```