### PR TITLE
fix version filter

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -16,7 +16,7 @@ function sort_versions() {
 # filter out versions before 3.22.1 -- the start of the calicoctl releases
 # in the new repo
 function filter_before() {
-  sed -n '/3\.22\.1/,$p'
+  sed -n '/3\.22\.[0-9]/,$p'
 }
 
 function get_tags() {


### PR DESCRIPTION
As the version `3.22.1` is not found anymore the version filter is broken.

The newest version in `list-all` is `3.21.6` so if you specify `latest` you will get `3.21.6` instead of `3.27.0`

This fix uses `3.22.x` in the filter_before function.