### PR TITLE
remove outdated legacy repo

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-legacy_releases_path=https://api.github.com/repos/projectcalico/calicoctl/releases
 releases_path=https://api.github.com/repos/projectcalico/calico/releases
 
 cmd="curl -s"
@@ -13,15 +12,8 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-# filter out versions before 3.22.1 -- the start of the calicoctl releases
-# in the new repo
-function filter_before() {
-  sed -n '/3\.22\.[0-9]/,$p'
-}
-
 function get_tags() {
   grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//'
 }
 
-echo $(eval "$cmd $legacy_releases_path" | get_tags | sort_versions) \
-     $(eval "$cmd $releases_path" | get_tags | sort_versions | filter_before)
+echo $(eval "$cmd $releases_path" | get_tags | sort_versions )


### PR DESCRIPTION
The current `list_all` delivers v3.21.6 as newest version which is wrong (should be v3.29.3).

This happens because a version v3.22.x used as filter is not delivered anymore in the api call (to old, we would have to use pagination stuff).

AFAIS it is sufficient to deliver the last 30 versions from github, with that, there is no need to read the old legacy repo anymore.

For fixing the wrong latest version I decided to remove the old legacy repo and the filter stuff.

Feel free to use another approach for fixing this.